### PR TITLE
Added script parameters, cmdletbinding, and minor readability changes.

### DIFF
--- a/Installer/Install.ps1
+++ b/Installer/Install.ps1
@@ -2,15 +2,16 @@
 # Install.ps1
 #
 
-$verbosePreference = "Continue"
-
-# Location and share name for the new deployment share
-$psDeploymentFolder = "C:\PSDeploymentShare"
-$psDeploymentShare = "PSDeploymentShare$"
+[CmdletBinding()]
+Param (
+    [Parameter(Position=0)][Alias("Path")][String]$psDeploymentFolder = "C:\PSDeploymentShare",   # Deployment share location
+    [Parameter(Position=1)][Alias("ShareName")][String]$psDeploymentShare = "PSDeploymentShare$", # Deployment share name
+    [Parameter()][Alias("FullAccess")][String[]]$psShareFullAccess = @(, 'Administrators')        # Users/Groups to be given full share access
+)
 
 # Create the folder and share
-New-Item -Path $psDeploymentFolder -ItemType directory
-New-SmbShare -Name $psDeploymentShare -Path $psDeploymentFolder -FullAccess Administrators
+$null = New-Item -Path $psDeploymentFolder -ItemType Directory
+$null = New-SmbShare -Name $psDeploymentShare -Path $psDeploymentFolder -FullAccess $psShareFullAccess
 
 # Find the folder this script is in
 $install = Split-Path -Path "$PSScriptRoot"
@@ -24,44 +25,52 @@ Import-Module "$($mdtDir)Bin\MicrosoftDeploymentToolkit.psd1"
 $null = New-PSDrive -Name PSD -PSProvider MDTProvider -Root $psDeploymentFolder
 
 # Copy the scripts
-Copy-Item "$install\Scripts\*.*" "$psDeploymentFolder\Scripts" -Recurse
-Dir "$psDeploymentFolder\Scripts\*.ps*" | Unblock-File 
+Copy-Item -Path "$install\Scripts\*.*" -Destination "$psDeploymentFolder\Scripts" -Recurse
+Get-ChildItem -Path "$psDeploymentFolder\Scripts\*.ps*" | Unblock-File 
 
 # Copy the templates
-Copy-Item "$install\Templates\*.*" "$psDeploymentFolder\Templates" -Recurse
-Dir "$psDeploymentFolder\Templates\*.*" | Unblock-File
+Copy-Item -Path "$install\Templates\*.*" -Destination "$psDeploymentFolder\Templates" -Recurse
+Get-ChildItem -Path "$psDeploymentFolder\Templates\*.*" | Unblock-File
 
 # Copy the provider module files
-if ((Test-Path "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn") -eq $false)
+if ((Test-Path -Path "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn") -eq $false)
 {
-    $null = New-Item "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn" -ItemType directory
+    $null = New-Item -Path "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn" -ItemType Directory
 }
-Copy-Item "$($mdtDir)Bin\Microsoft.BDD.PSSnapIn.dll" "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn"
-Copy-Item "$($mdtDir)Bin\Microsoft.BDD.PSSnapIn.dll.config" "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn"
-Copy-Item "$($mdtDir)Bin\Microsoft.BDD.PSSnapIn.dll-help.xml" "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn"
-Copy-Item "$($mdtDir)Bin\Microsoft.BDD.PSSnapIn.Format.ps1xml" "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn"
-Copy-Item "$($mdtDir)Bin\Microsoft.BDD.PSSnapIn.Types.ps1xml" "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn"
-Copy-Item "$($mdtDir)Bin\Microsoft.BDD.Core.dll" "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn"
-Copy-Item "$($mdtDir)Bin\Microsoft.BDD.Core.dll.config" "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn"
-Copy-Item "$($mdtDir)Bin\Microsoft.BDD.ConfigManager.dll" "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn"
+
+'Microsoft.BDD.PSSnapIn.dll',
+'Microsoft.BDD.PSSnapIn.dll.config',
+'Microsoft.BDD.PSSnapIn.dll-help.xml',
+'Microsoft.BDD.PSSnapIn.Format.ps1xml',
+'Microsoft.BDD.PSSnapIn.Types.ps1xml',
+'Microsoft.BDD.Core.dll',
+'Microsoft.BDD.Core.dll.config',
+'Microsoft.BDD.ConfigManager.dll' | ForEach-Object {
+    
+    Copy-Item -Path "$($mdtDir)Bin\$_" -Destination "$psDeploymentFolder\Tools\Modules\Microsoft.BDD.PSSnapIn"
+}
 
 # Copy the provider template files
-if ((Test-Path "$psDeploymentFolder\Templates") -eq $false)
+if ((Test-Path -Path "$psDeploymentFolder\Templates") -eq $false)
 {
-    $null = New-Item "$psDeploymentFolder\Templates"
+    $null = New-Item -Path "$psDeploymentFolder\Templates" -ItemType Directory
 }
-Copy-Item "$($mdtDir)Templates\Groups.xsd" "$psDeploymentFolder\Templates"
-Copy-Item "$($mdtDir)Templates\Medias.xsd" "$psDeploymentFolder\Templates"
-Copy-Item "$($mdtDir)Templates\OperatingSystems.xsd" "$psDeploymentFolder\Templates"
-Copy-Item "$($mdtDir)Templates\Packages.xsd" "$psDeploymentFolder\Templates"
-Copy-Item "$($mdtDir)Templates\SelectionProfiles.xsd" "$psDeploymentFolder\Templates"
-Copy-Item "$($mdtDir)Templates\TaskSequences.xsd" "$psDeploymentFolder\Templates"
-Copy-Item "$($mdtDir)Templates\Applications.xsd" "$psDeploymentFolder\Templates"
-Copy-Item "$($mdtDir)Templates\Drivers.xsd" "$psDeploymentFolder\Templates"
-Copy-Item "$($mdtDir)Templates\Groups.xsd" "$psDeploymentFolder\Templates"
+
+'Groups.xsd',
+'Medias.xsd',
+'OperatingSystems.xsd',
+'Packages.xsd',
+'SelectionProfiles.xsd',
+'TaskSequences.xsd',
+'Applications.xsd',
+'Drivers.xsd',
+'Groups.xsd' | ForEach-Object {
+    
+    Copy-Item -Path "$($mdtDir)Templates\$_" -Destination "$psDeploymentFolder\Templates"
+}
 
 # Update the ISO properties
-Set-ItemProperty PSD: -Name "Boot.x86.LiteTouchISOName" -Value "PSDLiteTouch_x86.iso"
-Set-ItemProperty PSD: -Name "Boot.x86.LiteTouchWIMDescription" -Value "PowerShell Deployment Boot Image (x86)"
-Set-ItemProperty PSD: -Name "Boot.x64.LiteTouchISOName" -Value "PSDLiteTouch_x64.iso"
-Set-ItemProperty PSD: -Name "Boot.x64.LiteTouchWIMDescription" -Value "PowerShell Deployment Boot Image (x64)"
+Set-ItemProperty -Path PSD: -Name "Boot.x86.LiteTouchISOName" -Value "PSDLiteTouch_x86.iso"
+Set-ItemProperty -Path PSD: -Name "Boot.x86.LiteTouchWIMDescription" -Value "PowerShell Deployment Boot Image (x86)"
+Set-ItemProperty -Path PSD: -Name "Boot.x64.LiteTouchISOName" -Value "PSDLiteTouch_x64.iso"
+Set-ItemProperty -Path PSD: -Name "Boot.x64.LiteTouchWIMDescription" -Value "PowerShell Deployment Boot Image (x64)"


### PR DESCRIPTION
Moved hardcoded $psDeploymentFolder, $psDeploymentShare and "-FullAccess" list to param block with default values.  This makes the script much more usable for my team by allowing the creation of multiple test shares with a quick one-liner, but does not change the structure or spirit too much.
``` powershell
"TestShare1", "TestShare2", "TestShare3" | ForEach-Object { .\Install.ps1 -Path "E:\$_" -ShareName "$_$" -FullAccess 'Administrators', 'serviceaccount1', 'serviceaccount2' }
```

Added cmdletbinding and removed $verbosePreference to allow verbose to be specified by the user.  Lots of terminal output can become really annoying when you are multitasking or trying to automate something.
``` powershell
.\Install.ps1 -Path E:\TestShare -ShareName TestShare$ -Verbose
```

Made things a bit more readable by moving some repetitive Copy-Item calls into a list/loop.  Replaced some aliases with explicit cmdlet names.  Added parameter names to some cmdlet calls for consistency.